### PR TITLE
Fixed date comparison error causing failure of global TOA plotting.

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -21,6 +21,7 @@ import pandas as pd
 from util import time as util_time
 import getpass
 from astropy.time import Time as astrotime
+import pytz
 
 from tables import *
 from joins import *
@@ -600,7 +601,7 @@ def get_proc_embargo(proc_id, client, url, token):
     # Check for valid processing ID
     if not (proc_data == None):
         embargoEnd = proc_data['embargoEnd']
-        return pd.to_datetime(embargoEnd)
+        return pytz.utc.localize(pd.to_datetime(embargoEnd).to_pydatetime())
     else:
         return
 


### PR DESCRIPTION
A previous merge implemented a timezone fix to a datetime object during Embargo date handling in `archive_utils.py`. A matching fix needed to be applied to `db_utils.py`, failure to do so has caused a number of global TOA plots not to generate.